### PR TITLE
Added character replacements for all Windows illegal characters

### DIFF
--- a/doc/readme.eu.md
+++ b/doc/readme.eu.md
@@ -10,6 +10,7 @@ Jatorrizko bertsioa:
 - [Igo beharreko fitxategien izenaren formatua](#fitxategi-izen-formatua)
   - [Izenaren formatua](#izen-formatua)
   - [Izenaren parametroak](#izen-parametroak)
+    - [Kapitulu izenburuen karaktere ordezkatzeak](#kapitulu-izenburuen-karaktere-ordezkatzeak)
   - [Onartutako Fitxategi Formatuak](#onartutako-fitxategi-formatuak)
 - [Konfigurazioa](#konfigurazioa)
   - [Erabiltzailearen Ezarpenak](#erabiltzailearen-ezarpenak)
@@ -44,9 +45,20 @@ Komando-lerroko argumentuak daude komando nagusiaren ondoren gehi daitezkeenak p
 - `[hizkuntza]` Kapituluaren hizkuntza-kodea ISO formatuan. *Ingeleserako ez da beharrezkoa.*
 - `cXXX` Kapituluaren zenbakia. *Kendu kapituluaren aurrizkia titulua kapitulu bakarrekoa bada (Oneshot), adibidez `cXXX` > `XXX`.*
 - `(vYY)` Kapituluaren bolumena. *Ez da derrigorrezkoa.*
-- `(kapitulu_izena)` Kapituluaren izenburua. `?` karakterearen ordez, `{question_mark}` erabili. *Ez da derrigorrezkoa.*
+- `(kapitulu_izena)` Kapituluaren izenburua. Ikus [Kapitulu izenburuen karaktere ordezkatzeak](#kapitulu-izenburuen-karaktere-ordezkatzeak). *Ez da derrigorrezkoa.*
 - `{argitaratze_data}` Kapitulua MangaDexen argitaratzeko nahi den etorkizuneko data. **Ezartzen bada, `YYYY-MM-DDTHH-MM-SS` formatua jarraitu behar du.** *Ez da derrigorrezkoa.*
 - `[taldea(k)]` Taldeen izenen edo IDen zerrenda. Talde-izenak badira, `name_id_map.json`-en IDekin batera sartu behar dira. *Talde bat baino gehiago bereizi `+` erabiliz.* *Ez da derrigorrezkoa.*
+
+##### Kapitulu izenburuen karaktere ordezkatzeak
+- `{asterisk}`: `*` *`{asterisk}` ordezkapena `*` bezala irakurriko da igoera prozesuan.*
+- `{backslash}`: `\` *`{backslash}` ordezkapena `\` bezala irakurriko da igoera prozesuan.*
+- `{slash}`: `/` *`{slash}` ordezkapena `/` bezala irakurriko da igoera prozesuan.*
+- `{colon}`: `:` *`{colon}` ordezkapena `:` bezala irakurriko da igoera prozesuan.*
+- `{greater_than}`: `>` *`{greater_than}` ordezkapena `>` bezala irakurriko da igoera prozesuan.*
+- `{less_than}`: `<` *`{less_than}` ordezkapena `<` bezala irakurriko da igoera prozesuan.*
+- `{question_mark}`: `?` *`{question_mark}` ordezkapena `?` bezala irakurriko da igoera prozesuan.*
+- `{quote}`: `"` *`{quote}` ordezkapena `"` bezala irakurriko da igoera prozesuan.*
+- `{pipe}`: `|` *`{pipe}` ordezkapena `|` bezala irakurriko da igoera prozesuan.*
 
 #### Onartutako Fitxategi Formatuak
 - `png`

--- a/mupl/file_validator.py
+++ b/mupl/file_validator.py
@@ -28,6 +28,17 @@ UUID_REGEX = re.compile(
     re.IGNORECASE,
 )
 
+WINDOWS_ILLEGAL_CHAR_MAP = {
+    '{backslash}': '\\',
+    '{slash}': '/',
+    '{colon}': ':',
+    '{asterisk}': '*',
+    '{question_mark}': '?',
+    '{quote}': '"',
+    '{less_than}': '<',
+    '{greater_than}': '>',
+    '{pipe}': '|'
+}
 
 class FileProcesser:
     def __init__(self, to_upload: "Path", names_to_ids: "dict") -> None:
@@ -120,8 +131,10 @@ class FileProcesser:
         """Get the chapter title from the file if it exists."""
         chapter_title = self._zip_name_match.group("chapter_title")
         if chapter_title is not None:
-            # Add the question mark back to the chapter title
-            chapter_title = chapter_title.strip().replace(r"{question_mark}", "?")
+            chapter_title = chapter_title.strip()
+            # Replace illegal characters in the chapter title
+            for placeholder, char in WINDOWS_ILLEGAL_CHAR_MAP.items():
+                chapter_title = chapter_title.replace(placeholder, char)
         return chapter_title
 
     def _get_publish_date(self) -> "Optional[str]":

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Read this in other languages:
 - [Upload file name structure](#file-name-structure)
   - [Name convention](#name-convention)
   - [Name parameters](#name-parameters)
+    - [Chapter title replacement characters](#chapter-title-replacement-characters)
   - [Accepted Image Formats](#accepted-image-formats)
   - [Image size](#image-size)
     - [Image Splitting](#image-splitting)
@@ -78,9 +79,20 @@ There are command line arguments that can be added after the main command to cha
 - `[lang]` Language code in the ISO format. *Omitted for English.*
 - `cXXX` Chapter number. *Omit the chapter prefix if the chapter is a oneshot, e.g. `cXXX` > `XXX`.*
 - `(vYY)` Chapter volume. *Optional.*
-- `(chapter_title)` Chapter title. Use `{question_mark}` in place where there would be a `?`. *Optional.*
+- `(chapter_title)` Chapter title. See [Chapter title replacement characters](#chapter-title-replacement-characters) for special characters. *Optional.*
 - `{publish_date}` Future date of when chapter is released from MangaDex's side. ***MUST** be in the format `YYYY-MM-DDTHH-MM-SS` if included.* *Optional.*
 - `[group]` List of group names or IDs. If group names, they must be included in the `name_id_map.json` for the IDs. *Separate multiple groups using `+`.* *Optional.*
+
+##### Chapter title replacement characters
+- `{asterisk}` `*` *`{asterisk}` will be replaced with `*` during the upload process.*
+- `{backslash}` `\` *`{backslash}` will be replaced with `\` during the upload process.*
+- `{slash}` `/` *`{slash}` will be replaced with `/` during the upload process.*
+- `{colon}` `:` *`{colon}` will be replaced with `:` during the upload process.*
+- `{greater_than}` `>` *`{greater_than}` will be replaced with `>` during the upload process.*
+- `{less_than}` `<` *`{less_than}` will be replaced with `<` during the upload process.*
+- `{question_mark}` `?` *`{question_mark}` will be replaced with `?` during the upload process.*
+- `{quote}` `"` *`{quote}` will be replaced with `"` during the upload process.*
+- `{pipe}` `|` *`{pipe}` will be replaced with `|` during the upload process.*
 
 #### Accepted Image formats
 - `png`


### PR DESCRIPTION
This pull request includes changes to documentation and code to support the replacement of special characters in chapter titles. The most important changes include updates to the documentation files to include information about character replacements and modifications to the `mupl/file_validator.py` script to handle these replacements.

Documentation updates:

* [`doc/readme.eu.md`](diffhunk://#diff-c7916aee131a5ec42756fe4fe30047a10992a2d0c1752e7a6aba342abeb5dbbeR13): Added a section on chapter title character replacements and updated references to this new section. [[1]](diffhunk://#diff-c7916aee131a5ec42756fe4fe30047a10992a2d0c1752e7a6aba342abeb5dbbeR13) [[2]](diffhunk://#diff-c7916aee131a5ec42756fe4fe30047a10992a2d0c1752e7a6aba342abeb5dbbeL47-R62)
* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R23): Added a section on chapter title character replacements and updated references to this new section. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R23) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L81-R96)

Code updates:

* [`mupl/file_validator.py`](diffhunk://#diff-0f156635e1f0b674b71080b97e4af446c538b03e0f132473c63ceb3f82c8d6eaR31-R41): Introduced a `WINDOWS_ILLEGAL_CHAR_MAP` dictionary to map placeholders to illegal characters and updated the `_get_chapter_title` method to replace placeholders with the corresponding characters. [[1]](diffhunk://#diff-0f156635e1f0b674b71080b97e4af446c538b03e0f132473c63ceb3f82c8d6eaR31-R41) [[2]](diffhunk://#diff-0f156635e1f0b674b71080b97e4af446c538b03e0f132473c63ceb3f82c8d6eaL123-R137)