### PR TITLE
Regex fix for empty publish time/chapter title value

### DIFF
--- a/mupl/file_validator.py
+++ b/mupl/file_validator.py
@@ -15,7 +15,7 @@ FILE_NAME_REGEX = re.compile(
     r"(?:\s?\[(?P<language>[a-z]{2}(?:-[a-z]{2})?|[a-zA-Z]{3}|[a-zA-Z]+)?\])?\s-\s"  # Language
     r"(?P<prefix>(?:[c](?:h(?:a?p?(?:ter)?)?)?\.?\s?))?(?P<chapter>\d+(?:\.\d+)?)"  # Chapter number and prefix
     r"(?:\s?\((?:[v](?:ol(?:ume)?(?:s)?)?\.?\s?)?(?P<volume>\d+(?:\.\d+)?)?\))?"  # Volume number
-    r"(?:\s?\((?P<chapter_title>.+)\))?"  # Chapter title
+    r"(?:\s?\((?P<chapter_title>.+)?\))?"  # Chapter title
     r"(?:\s?\{(?P<publish_date>(?P<publish_year>\d{4})-(?P<publish_month>\d{2})-(?P<publish_day>\d{2})(?:[T\s](?P<publish_hour>\d{2})[\:\-](?P<publish_minute>\d{2})(?:[\:\-](?P<publish_microsecond>\d{2}))?(?:(?P<publish_offset>[+-])(?P<publish_timezone>\d{2}[\:\-]?\d{2}))?)?)\})?"  # Publish date
     r"(?:\s?\[(?:(?P<group>.+))?\])?"  # Groups
     r"(?:\s?\{v?(?P<version>\d)?\})?"  # Chapter version

--- a/mupl/file_validator.py
+++ b/mupl/file_validator.py
@@ -16,7 +16,7 @@ FILE_NAME_REGEX = re.compile(
     r"(?P<prefix>(?:[c](?:h(?:a?p?(?:ter)?)?)?\.?\s?))?(?P<chapter>\d+(?:\.\d+)?)"  # Chapter number and prefix
     r"(?:\s?\((?:[v](?:ol(?:ume)?(?:s)?)?\.?\s?)?(?P<volume>\d+(?:\.\d+)?)?\))?"  # Volume number
     r"(?:\s?\((?P<chapter_title>.+)?\))?"  # Chapter title
-    r"(?:\s?\{(?P<publish_date>(?P<publish_year>\d{4})-(?P<publish_month>\d{2})-(?P<publish_day>\d{2})(?:[T\s](?P<publish_hour>\d{2})[\:\-](?P<publish_minute>\d{2})(?:[\:\-](?P<publish_microsecond>\d{2}))?(?:(?P<publish_offset>[+-])(?P<publish_timezone>\d{2}[\:\-]?\d{2}))?)?)\})?"  # Publish date
+    r"(?:\s?\{(?P<publish_date>(?P<publish_year>\d{4})-(?P<publish_month>\d{2})-(?P<publish_day>\d{2})(?:[T\s](?P<publish_hour>\d{2})[\:\-](?P<publish_minute>\d{2})(?:[\:\-](?P<publish_microsecond>\d{2}))?(?:(?P<publish_offset>[+-])(?P<publish_timezone>\d{2}[\:\-]?\d{2}))?)?)?\})?"  # Publish date
     r"(?:\s?\[(?:(?P<group>.+))?\])?"  # Groups
     r"(?:\s?\{v?(?P<version>\d)?\})?"  # Chapter version
     r"(?:\.(?P<extension>zip|cbz))?$",  # File extension


### PR DESCRIPTION
Missing quantifier makes the regex fail when the chapter title is empty. By empty I mean a filename like so:
`Rurouni-Kenshin-Meiji-Kenkaku-Romantan [es-la] - c001 (v1) () [Up!Subs_]`

Here is what happens currently:

https://github.com/user-attachments/assets/348f76e2-297a-43c3-b24b-58a8eb983081

I've also added it for publish time. It makes it more consistent across the board since it's already permitted to have empty values for at least volume and group.