### PR TITLE
fix image combining(?)

### DIFF
--- a/mupl/image_validator.py
+++ b/mupl/image_validator.py
@@ -103,14 +103,7 @@ class ImageProcessorBase:
         for img_name, img_bytes in images:
             with Image.open(io.BytesIO(img_bytes)) as img:
                 width, height = img.size
-
-                if not ImageProcessorBase._is_image_large_enough(img_bytes, min_size):
-                    logger.info(
-                        f"Skipping {img_name} as it is smaller than {min_size}."
-                    )
-                    print(TRANSLATION["image_skip"].format(img_name, min_size, "size"))
-                    continue
-
+                
                 if current_image is None:
                     current_image = img.copy()
                     current_name = img_name


### PR DESCRIPTION
When I was trying to use the image combining function, it skipped images for being below the minimum size, which is precisely why I wanted to merge them so that seemed odd.
Looking at the code, this check seems to be at fault but at the same time, I feel like there might've been a reason for it to be there which I missed. However, the only way I could make sense of this was that the check meant to be made there was
```py
if width <= min_size and height <= min_size:
```
If that guess is correct, I can adjust the PR accordingly...