### PR TITLE
Move termsAccepted to its correct location

### DIFF
--- a/mupl/uploader/handler.py
+++ b/mupl/uploader/handler.py
@@ -249,9 +249,9 @@ class ChapterUploaderHandler:
                 "volume": self.file_name_obj.volume_number,
                 "chapter": self.file_name_obj.chapter_number,
                 "title": self.file_name_obj.chapter_title,
-                "translatedLanguage": self.file_name_obj.language,
-                "termsAccepted": True
+                "translatedLanguage": self.file_name_obj.language
             },
+            "termsAccepted": True,
             "pageOrder": self.images_to_upload_ids,
         }
 


### PR DESCRIPTION
It should be in the root of the payload, not inside chapterDraft (whoops)